### PR TITLE
Added possibility to install different version of rundeck

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,11 @@
 ---
 # defaults file for rundeck
 
+# Rundeck version to install
+rundeck_version: 3.2.3
+rundeck_release_date: 20200221
+rundeck_download_url: "https://dl.bintray.com/rundeck/rundeck-maven/rundeck-{{ rundeck_version }}-{{ rundeck_release_date }}.war"
+
 # Where to install rundeck.
 rundeck_rdeckbase: /opt/rundeck
 
@@ -18,6 +23,8 @@ rundeck_server_web_context: /
 rundeck_url: "http://{{ rundeck_address }}:{{ rundeck_port }}{{ rundeck_server_web_context }}"
 
 rundeck_config:
+  - parameter: server.address
+    value: "{{ rundeck_address }}"
   - parameter: grails.serverURL
     value: "{{ rundeck_url }}"
 
@@ -61,5 +68,6 @@ rundeck_users:
     password: "user"
     roles: "user"
 
-rundeck_plugins:
-  - https://github.com/Batix/rundeck-ansible-plugin/releases/download/3.1.1/ansible-plugin-3.1.1.jar
+# Rundeck plugins to install
+rundeck_plugins: []
+  # - https://github.com/Batix/rundeck-ansible-plugin/releases/download/3.1.1/ansible-plugin-3.1.1.jar

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,5 @@
 ---
 # vars file for rundeck
-rundeck_version: 3.2.3
-rundeck_release_date: 20200221
-rundeck_download_url: "https://dl.bintray.com/rundeck/rundeck-maven/rundeck-{{ rundeck_version }}-{{ rundeck_release_date }}.war"
 rundeck_jar: rundeck-launcher-{{ rundeck_version }}.jar
 rundeck_war: "{{ rundeck_rdeckbase }}/rundeck-{{ rundeck_version }}-{{ rundeck_release_date }}.war"
 


### PR DESCRIPTION
---
name: Added possibility to install different version of rundeck
---

**Describe the change**
Main goal of this PR is to let role user to overwrite `rundeck_version`, `rundeck_release_date` and `rundeck_download_url` variables. 

Additionally, it sets `server.address` tp `{{ rundeck_address }}` value in `rundeck-config.properties` - rundeck is taking this from the hostname by default.
It also disables default ansible plugin installation. (not all use cases of rundeck requires this plugin to exists) 


