### PR TITLE
MySQL Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ rundeck_config:
 #   - parameter: dataSource.password
 #     value: rundeck
 #   - parameter: dataSource.driverClassName
-#     value: com.mysql.jdbc.Driver
+#     value: org.mariadb.jdbc.Driver
 
 # The settings for Rundeck. (Stored in: "{{ rundeck_rdeckbase }}/etc/framework.properties".)
 rundeck_framework:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,7 @@ rundeck_config:
 #   - parameter: dataSource.password
 #     value: rundeck
 #   - parameter: dataSource.driverClassName
-#     value: com.mysql.jdbc.Driver
+#     value: org.mariadb.jdbc.Driver
 
 # The settings for Rundeck. (Stored in: "{{ rundeck_rdeckbase }}/etc/framework.properties".)
 rundeck_framework:


### PR DESCRIPTION
---
name: Add working Driver for MySQL
about: The Default MySQL JDBC Driver doesn't work anymore and needs to be replaced by the `mariadb` one.

---

**Describe the change**
Replacing `com.mysql.jdbc.Driver` by `org.mariadb.jdbc.Driver`
